### PR TITLE
wip: add ParseMode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,5 @@ mod result;
 mod utf8;
 
 pub use error::{Error, ErrorKind};
-pub use pikkr::Pikkr;
+pub use pikkr::{CountedParser, Pikkr};
 pub use result::Result;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,15 +11,10 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &mut FnvHa
     let cp = generate_colon_positions(index, start, end, level);
     let mut vei = end;
     for i in (0..cp.len()).rev() {
-        let (fsi, fei) = match search_pre_field_indices(b_quote, if i > 0 { cp[i - 1] } else { start }, cp[i]) {
-            Ok(fsei) => fsei,
-            Err(e) => {
-                return Err(e);
-            }
-        };
+        let (fsi, fei) = search_pre_field_indices(b_quote, if i > 0 { cp[i - 1] } else { start }, cp[i])?;
         let field = &rec[fsi + 1..fei];
         if let Some(query) = queries.get_mut(field) {
-            let (vsi, vei) = match search_post_value_indices(
+            let (vsi, vei) = search_post_value_indices(
                 rec,
                 cp[i] + 1,
                 vei,
@@ -28,18 +23,13 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &mut FnvHa
                 } else {
                     COMMA
                 },
-            ) {
-                Ok(vsei) => vsei,
-                Err(e) => {
-                    return Err(e);
-                }
-            };
+            )?;
             found_num += 1;
             if set_stats && !stats[query.i].contains(&i) {
                 stats[query.i].insert(i);
             }
             if let Some(ref mut children) = query.children {
-                if let Err(e) = basic_parse(
+                basic_parse(
                     rec,
                     index,
                     children,
@@ -51,9 +41,7 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &mut FnvHa
                     set_stats,
                     results,
                     b_quote,
-                ) {
-                    return Err(e);
-                };
+                )?;
             }
             if query.target {
                 results[query.ri] = Some(&rec[vsi..vei + 1]);
@@ -76,26 +64,16 @@ pub fn speculative_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &Fnv
             if *i >= cp.len() {
                 continue;
             }
-            let (fsi, fei) = match search_pre_field_indices(b_quote, if *i > 0 { cp[*i - 1] } else { start }, cp[*i]) {
-                Ok(fsei) => fsei,
-                Err(e) => {
-                    return Err(e);
-                }
-            };
+            let (fsi, fei) = search_pre_field_indices(b_quote, if *i > 0 { cp[*i - 1] } else { start }, cp[*i])?;
             let field = &rec[fsi + 1..fei];
             if s == &field {
                 let vei = if *i < cp.len() - 1 {
-                    let nfsi = match search_pre_field_indices(b_quote, cp[*i], cp[*i + 1]) {
-                        Ok((nfsi, _)) => nfsi,
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    };
+                    let (nfsi, _) = search_pre_field_indices(b_quote, cp[*i], cp[*i + 1])?;
                     nfsi - 1
                 } else {
                     end
                 };
-                let (vsi, vei) = match search_post_value_indices(
+                let (vsi, vei) = search_post_value_indices(
                     rec,
                     cp[*i] + 1,
                     vei,
@@ -104,14 +82,9 @@ pub fn speculative_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &Fnv
                     } else {
                         COMMA
                     },
-                ) {
-                    Ok(vsei) => vsei,
-                    Err(e) => {
-                        return Err(e);
-                    }
-                };
+                )?;
                 if let Some(ref children) = q.children {
-                    found = match speculative_parse(
+                    found = speculative_parse(
                         rec,
                         index,
                         children,
@@ -121,10 +94,7 @@ pub fn speculative_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &Fnv
                         stats,
                         results,
                         b_quote,
-                    ) {
-                        Ok(found) => found,
-                        Err(e) => return Err(e),
-                    };
+                    )?;
                 } else {
                     found = true;
                 }

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -121,9 +121,7 @@ impl<'a> Pikkr<'a> {
         }
 
         let mut index = Vec::with_capacity(self.level);
-        if let Err(e) = index_builder::build_leveled_colon_bitmap(&b_colon, &b_left, &b_right, self.level, &mut index) {
-            return Err(e);
-        };
+        index_builder::build_leveled_colon_bitmap(&b_colon, &b_left, &b_right, self.level, &mut index)?;
 
         let mut results = Vec::with_capacity(self.query_strs_len);
         for _ in 0..self.query_strs_len {
@@ -132,7 +130,7 @@ impl<'a> Pikkr<'a> {
 
         match mode {
             ParseMode::Speculative => {
-                let found = match parser::speculative_parse(
+                let found = parser::speculative_parse(
                     rec,
                     &index,
                     &self.queries,
@@ -142,14 +140,9 @@ impl<'a> Pikkr<'a> {
                     &self.stats,
                     &mut results,
                     &b_quote,
-                ) {
-                    Ok(found) => found,
-                    Err(e) => {
-                        return Err(e);
-                    }
-                };
+                )?;
                 if !found {
-                    if let Err(e) = parser::basic_parse(
+                    parser::basic_parse(
                         rec,
                         &index,
                         &mut self.queries,
@@ -161,13 +154,11 @@ impl<'a> Pikkr<'a> {
                         false,
                         &mut results,
                         &b_quote,
-                    ) {
-                        return Err(e);
-                    };
+                    )?;
                 }
             }
             ParseMode::Basic => {
-                if let Err(e) = parser::basic_parse(
+                parser::basic_parse(
                     rec,
                     &index,
                     &mut self.queries,
@@ -179,9 +170,7 @@ impl<'a> Pikkr<'a> {
                     true,
                     &mut results,
                     &b_quote,
-                ) {
-                    return Err(e);
-                };
+                )?;
             }
         }
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -2,7 +2,7 @@ extern crate pikkr;
 
 #[allow(non_snake_case)]
 mod issues {
-    use pikkr::Pikkr;
+    use pikkr::CountedParser as Pikkr;
     use pikkr::ErrorKind;
 
     /// The helper macro for test cases.


### PR DESCRIPTION
draft

---

Note that this PR contains some breaking changes for library's users.

If the conventional parser is required, the following struct is useful:

```rust
struct CountedParser<'a> {
    inner: Pikkr<'a>,
    num_train: usize,
    num_trained: usize,
}

impl<'a> CountedParser<'a> {
    pub fn new(queries: &[&str], num_train: usize) -> Result<Self> {
        Ok(CountedParser {
            inner: Pikkr::new(queries)?,
            num_train,
            num_trained: 0,
        })
    }

    #[inline(always)]
    pub fn parse(rec: &str) -> Vec<Option<&[u8]>> {
        if self.num_trained >= self.num_train {
            self.inner.parse(rec, ParseMode::Speculative)
        } else {
            self.num_trained += 1;
            self.inner.parse(rec, ParseMode::Basic)
        }
    }
}